### PR TITLE
support for hidden data

### DIFF
--- a/src/Prolog/Programming/ExampleConfig.hs
+++ b/src/Prolog/Programming/ExampleConfig.hs
@@ -60,5 +60,12 @@ a_test_with_resolution_tree(right_branch) :- fail. % See test line 5
  * Be careful to avoid naming clashes to not confuse the student with error messages about code they can't see.
  * Clashes can be avoided by the 'filtered' include setting, but giving priority to the student's version of some
  * predicate can weaken the test suite.
+ *
+ * If a data constructor or constant begins with hidden__ then it will not be visible in feedback resulting from query tests.
+ * The results containing these construtors/constants still need to appear in the list of expected results.
+ * When the difference between the expected and actual query result contains only solutions with hidden data a special error message
+ * informs the student that their submission is not general enough (in the sense that its rules do not work for arbitrary data).
+ *
+ * Note that derivation trees are currently not subject to filtering of hidden data!
  */
   |]

--- a/src/Prolog/Programming/Task.hs
+++ b/src/Prolog/Programming/Task.hs
@@ -195,6 +195,7 @@ treeMsg = maybe empty (const (line <> text "Derivation tree:"))
 resultMsg :: Maybe [Unifier] -> Doc
 resultMsg Nothing =
   text "Your submission is not general enough."
+  <$$> text "(Your rules do not work on arbitrary data)"
 resultMsg (Just actual) =
   text "Your" <> align
     (text " submission gives:"

--- a/src/Prolog/Programming/Task.hs
+++ b/src/Prolog/Programming/Task.hs
@@ -195,7 +195,7 @@ treeMsg = maybe empty (const (line <> text "Derivation tree:"))
 resultMsg :: Maybe [Unifier] -> Doc
 resultMsg Nothing =
   text "Your submission is not general enough."
-  <$$> text "(Your rules do not work on arbitrary data)"
+  <$$> text "(Your program do not work on arbitrary data)"
 resultMsg (Just actual) =
   text "Your" <> align
     (text " submission gives:"


### PR DESCRIPTION
data constructors and constants whose names begin with `hidden__` are treated as hidden. They are filtered from the results in feedback. If the difference between expected and actual outcome of a test contains only solutions with hidden data, currently the feedback message reads `"Your submission is not general enough."`.

Open questions/issues:

- Is this feature too specific to the intended use in knowledge-base tasks? (does it need more flexible configuration options)
- How can we make the feedback message more helpful?
- Currently, derivation trees are not filtered, therefore trees can leak the hidden data.