### PR TITLE
do not ignore excess text in config lines

### DIFF
--- a/src/Prolog/Programming/ExampleConfig.hs
+++ b/src/Prolog/Programming/ExampleConfig.hs
@@ -19,10 +19,10 @@ exampleConfig = Config
  * %    - For task definitions clauses that occur identically in the input program are filtered out
  * % 'no': do not include.
  * % Both default to yes
- * Include hidden definitions: [ yes | filtered ]
- * Include task definitions: [ yes | filtered | no ]
+ * % Include hidden definitions: [ yes | filtered ]
+ * % Include task definitions: [ yes | filtered | no ]
  * % allow/disallow the use of [H|T] matching on list values, defaults to 'yes' (experimental: might not recognize all instances of the pattern)
- * Allow list pattern matching: [ yes | no ]
+ * % Allow list pattern matching: [ yes | no ]
  * % prefixing a test with [<time out in ms>] sets a local timeout for that test
  * a_predicate(Foo,Bar): a_predicate(expected_foo1,expected_bar1), a_predicate(expected_foo2,expected_bar2)
  * a_statement_that_has_to_be_true

--- a/src/Prolog/Programming/Parser.hs
+++ b/src/Prolog/Programming/Parser.hs
@@ -33,14 +33,15 @@ specification = do
   pure (fromMaybe 10000 mTimeout, fromMaybe QueryStyle mStyle, fromMaybe Yes mIncTask, fromMaybe Yes mIncHidden, fromMaybe True mListMatch, specs)
   where
     parseSpecLine :: (Integer, String) -> Either ParseError (Maybe SpecLine)
-    parseSpecLine (i, s) = parse
+    parseSpecLine (i, s) = parse (
         ((Nothing <$ commentLine)
          <|> (Just <$> ((TimeoutSpec <$> try globalTimeout)
                         <|> TreeStyleSpec <$> try treeStyle
                         <|> IncludeHiddenSpec <$> try includeHidden
                         <|> IncludeTaskSpec <$> try includeTask
                         <|> ListMatchSpec <$> try allowListMatching
-                        <|> TestSpec <$> (try newPredDeclParser <|> specLine))))
+                        <|> TestSpec <$> (try newPredDeclParser <|> specLine)))
+        ) <* eof)
         ("Specification line " ++ show i) s
 
     specLine = ((\f g h i -> f . g . h . i)


### PR DESCRIPTION
closes #24

I also edited the default config. There were some lines describing possible values for settings that were not correctly tagged as code comments.